### PR TITLE
Fix Data Not Found Error Message

### DIFF
--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -1,6 +1,6 @@
 import logging
-from fastapi import APIRouter, Depends, HTTPException, Query # type: ignore
-from pymongo import MongoClient # type: ignore
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pymongo import MongoClient
 from app.core.config import settings
 from app.api.analytics_service import aggregate_daily_summary, aggregate_summary_by_date_range
 from datetime import datetime, timedelta
@@ -98,7 +98,8 @@ async def get_analytics(
             raise HTTPException(status_code=404, detail=f"No data found for {date}")
         
         return parse_json(doc["summary"])
-
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/frontend/src/hooks/useAnalytics.tsx
+++ b/frontend/src/hooks/useAnalytics.tsx
@@ -60,14 +60,15 @@ export function useAnalytics(queryParams: QueryParams) {
           }
         );
         console.log("response", response)
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
+        
         if(response.status === 404) {
           setData(null);
           setIsLoading(false);
           return;
+        }
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
         }
 
         const jsonData = await response.json();

--- a/frontend/src/pages/Public/analytics.tsx
+++ b/frontend/src/pages/Public/analytics.tsx
@@ -272,7 +272,7 @@ export default function AnalyticsPage() {
   }
 
   if (!data) {
-    return <div className="text-center p-4">No data available</div>;
+    return <div className="text-center p-4 text-red-500">No data available</div>;
   }
 
   const handleDownloadPDF = () => {


### PR DESCRIPTION
Expected Behavior 
- Backend code should return a 404 if there is no data for a particular date.
- Frontend returns all 404 responses as `No Data Found` message

Issue
- The broad exception handler will catch all exceptions, including the HTTPException you just raised for 404, and re-raise them as a 500 error. Thus, the client always gets a 500, even when you intend to send a 404.
- In your frontend, you check for `!response.ok` and throw an error before checking for `response.status === 404`

Fix
- Backend - Only catch non-HTTPException errors using `except HTTPException: raise` from FastAPI
- Frontend - Check for 404 before throwing for other errors
